### PR TITLE
Andy api

### DIFF
--- a/controllers/commentController.js
+++ b/controllers/commentController.js
@@ -84,3 +84,30 @@ exports.deleteComment = async (req, res) => {
     res.status(500).json({ status: "error", message: "無法刪除留言" });
   }
 };
+
+exports.toggleCommentLike = async (req, res) => {
+  try {
+    const { comment_id } = req.params;
+    if (!req.user || !req.user.id) {
+      return res.status(401).json({ status: "error", message: "未授權，請登入" });
+    }
+
+    const result = await commentModel.toggleCommentLike(req.user.id, comment_id);
+    res.json({ status: "success", liked: result.liked });
+  } catch (error) {
+    console.error("按讚留言失敗:", error);
+    res.status(500).json({ status: "error", message: "無法按讚留言" });
+  }
+};
+
+exports.getCommentLikes = async (req, res) => {
+  try {
+    const { comment_id } = req.params;
+    const likes = await commentModel.getCommentLikes(comment_id);
+    res.json({ status: "success", data: likes });
+  } catch (error) {
+    console.error("無法獲取留言按讚名單:", error);
+    res.status(500).json({ status: "error", message: "無法獲取留言按讚名單" });
+  }
+};
+

--- a/controllers/postController.js
+++ b/controllers/postController.js
@@ -18,25 +18,25 @@ const { s3 } = require("../config-s3");
 
 
 
- // **通用 R2 上傳函式（支援 Base64 & 檔案）**
-const uploadToR2 = async (file, folder) =>{
+// **通用 R2 上傳函式（支援 Base64 & 檔案）**
+const uploadToR2 = async (file, folder) => {
   try {
     let fileBuffer; // 先宣告變數
     let fileName;
 
-    if(typeof file === "string" && file.startsWith("data:image")) {
+    if (typeof file === "string" && file.startsWith("data:image")) {
       // Base64 圖片處理
-      const base64Data =  file.split(",")[1];
+      const base64Data = file.split(",")[1];
       fileBuffer = Buffer.from(base64Data, "base64");
       fileName = `${folder}/${Date.now()}.png`; // **確保唯一檔名**
-    } 
+    }
     else if (file.path) {
       //正常檔案上傳 ✅ 處理一般檔案上傳 避免 R2 亂碼
       fileBuffer = fs.readFileSync(file.path);
-      let sanitizedFileName = file.originalname.normalize("NFC") 
-            .replace(/\s/g, "_")  // 空格轉 `_`
-            .replace(/[^\w.-]/g, ""); // 過濾特殊字符
-      fileName = `${folder}/${Date.now()}-${sanitizedFileName}`; 
+      let sanitizedFileName = file.originalname.normalize("NFC")
+        .replace(/\s/g, "_")  // 空格轉 `_`
+        .replace(/[^\w.-]/g, ""); // 過濾特殊字符
+      fileName = `${folder}/${Date.now()}-${sanitizedFileName}`;
     }
     else {
       throw new Error("無效的圖片格式");
@@ -48,7 +48,7 @@ const uploadToR2 = async (file, folder) =>{
     //初始化  ✅ 設定上傳參數 **上傳到 R2**
     const uploadParams = {
       Bucket: process.env.R2_BUCKET_NAME,
-      Key: fileName,  
+      Key: fileName,
       Body: fileBuffer,
       ContentType: file.mimetype || "image/png",
     }
@@ -59,20 +59,20 @@ const uploadToR2 = async (file, folder) =>{
     await s3.send(command);
 
     console.log("✅ 圖片成功上傳到 R2");
-    
+
     // 上傳成功後刪除本地檔案
-   // ✅ 確保刪除本地檔案  
-   if (file.path && fs.existsSync(file.path)) {
-    fs.unlink(file.path, (err) => {
-      if (err) console.error("❌ 刪除本地檔案失敗:", err);
-      else console.log("✅ 本地檔案刪除成功:", file.path);
-    });
-  }
+    // ✅ 確保刪除本地檔案  
+    if (file.path && fs.existsSync(file.path)) {
+      fs.unlink(file.path, (err) => {
+        if (err) console.error("❌ 刪除本地檔案失敗:", err);
+        else console.log("✅ 本地檔案刪除成功:", file.path);
+      });
+    }
 
     // **本地 vs 雲端 儲存不同 URL**
     const resultUrl = process.env.NODE_ENV === "development"
-    ? await getSignedUrl(s3, new GetObjectCommand(uploadParams), { expiresIn: 604800 })
-    : `${process.env.CDN_BASE_URL}api/image?key=${encodeURIComponent(fileName)}`; // **確保 URL 解析  ✅ 修正 `resultUrl`，確保 `key` 被 `encodeURIComponent()`**
+      ? await getSignedUrl(s3, new GetObjectCommand(uploadParams), { expiresIn: 604800 })
+      : `${process.env.CDN_BASE_URL}api/image?key=${encodeURIComponent(fileName)}`; // **確保 URL 解析  ✅ 修正 `resultUrl`，確保 `key` 被 `encodeURIComponent()`**
 
     console.log("📌 返回的圖片 URL:", resultUrl);
     return resultUrl;
@@ -167,7 +167,7 @@ exports.getPosts = async (req, res) => {
   }
 };
 
- // **根據 ID 取得文章**
+// **根據 ID 取得文章**
 exports.getPostById = async (req, res) => {
   try {
     const { id } = req.params;
@@ -226,8 +226,8 @@ exports.createPost = async (req, res) => {
 
     const { title, content, category_id, status, tags, image_url } = req.body;
 
-    if(!title || !content) {
-      return res.status(400).json({error: "標題與內容為必填"});
+    if (!title || !content) {
+      return res.status(400).json({ error: "標題與內容為必填" });
     }
 
 
@@ -238,7 +238,7 @@ exports.createPost = async (req, res) => {
       title,
       content, // 這裡已經是處理過的 HTML，內含 R2 圖片 URL
       status: status || 'draft',
-      image_url: image_url|| null // ✅ 存入轉換後的 URL
+      image_url: image_url || null // ✅ 存入轉換後的 URL
     };
 
     console.log("📌 正在新增文章"); // 🔴 **加上 log 檢查**
@@ -345,5 +345,35 @@ exports.getPostLikes = async (req, res) => {
     res.json({ status: "success", data: likes });
   } catch (error) {
     res.status(500).json({ status: "error", message: "無法查詢按讚數" });
+  }
+};
+
+
+exports.togglePostFavorite = async (req, res) => {
+  try {
+    const { post_id } = req.params;
+    if (!req.user || !req.user.id) {
+      return res.status(401).json({ status: "error", message: "未授權，請登入" });
+    }
+
+    const result = await postModel.togglePostFavorite(req.user.id, post_id);
+    res.json({ status: "success", favorited: result.favorited });
+  } catch (error) {
+    console.error("無法收藏/取消收藏文章:", error);
+    res.status(500).json({ status: "error", message: "無法收藏/取消收藏文章" });
+  }
+};
+
+exports.getUserFavorites = async (req, res) => {
+  try {
+    if (!req.user || !req.user.id) {
+      return res.status(401).json({ status: "error", message: "未授權，請登入" });
+    }
+
+    const favorites = await postModel.getUserFavorites(req.user.id);
+    res.json({ status: "success", data: favorites });
+  } catch (error) {
+    console.error("無法獲取收藏文章清單:", error);
+    res.status(500).json({ status: "error", message: "無法獲取收藏文章清單" });
   }
 };

--- a/migrations/20250304151635_create_comment_likes.js
+++ b/migrations/20250304151635_create_comment_likes.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  await knex.schema.createTable("comment_likes", function (table) {
+    table.uuid("user_id").references("id").inTable("users").onDelete("CASCADE");
+    table.uuid("comment_id").references("id").inTable("comments").onDelete("CASCADE");
+    table.primary(["user_id", "comment_id"]); // 避免重複按讚
+  });
+};
+
+/**
+* @param { import("knex").Knex } knex
+* @returns { Promise<void> }
+*/
+exports.down = async function (knex) {
+  await knex.schema.dropTableIfExists("comment_likes");
+};

--- a/migrations/20250304162539_create_post_favorites.js
+++ b/migrations/20250304162539_create_post_favorites.js
@@ -1,0 +1,21 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  return knex.schema.createTable("post_favorites", function (table) {
+    table.uuid("id").primary().defaultTo(knex.raw("gen_random_uuid()"));
+    table.uuid("user_id").references("id").inTable("users").onDelete("CASCADE");
+    table.uuid("post_id").references("id").inTable("posts").onDelete("CASCADE");
+    table.timestamp("created_at").defaultTo(knex.fn.now());
+    table.unique(["user_id", "post_id"]);
+  });
+};
+
+/**
+* @param { import("knex").Knex } knex
+* @returns { Promise<void> }
+*/
+exports.down = async function (knex) {
+  return knex.schema.dropTableIfExists("post_favorites");
+};

--- a/migrations/20250304172945_add_created_at_to_comments_likes.js
+++ b/migrations/20250304172945_add_created_at_to_comments_likes.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.alterTable("comment_likes", function (table) {
+    table.timestamp("created_at").defaultTo(knex.fn.now()).notNullable();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.alterTable("comment_likes", function (table) {
+    table.dropColumn("created_at");
+  });
+};

--- a/migrations/20250304175332_add_views_count_to_posts.js
+++ b/migrations/20250304175332_add_views_count_to_posts.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.alterTable("posts", function (table) {
+    table.integer("views_count").defaultTo(0).notNullable();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.alterTable("posts", function (table) {
+    table.dropColumn("views_count");
+  });
+};

--- a/models/commentModel.js
+++ b/models/commentModel.js
@@ -4,6 +4,7 @@ exports.getAllComments = async () => {
   const result = await db.query(`
         SELECT comments.*, 
                users.username AS user_name,
+               users.profile_picture,
                (SELECT COUNT(*) FROM comment_likes WHERE comment_likes.comment_id = comments.id) AS likes_count
         FROM comments
         JOIN users ON comments.user_id = users.id
@@ -16,6 +17,7 @@ exports.getCommentsByPostId = async (post_id) => {
   const result = await db.query(`
     SELECT comments.*, 
            users.username AS user_name,
+           users.profile_picture,
            (SELECT COUNT(*) FROM comment_likes WHERE comment_likes.comment_id = comments.id) AS likes_count
     FROM comments
     JOIN users ON comments.user_id = users.id
@@ -42,6 +44,7 @@ exports.getCommentsWithReplies = async (post_id) => {
   try {
     const result = await db.query(`
           SELECT comments.*, users.username AS user_name,
+          users.profile_picture,
            (SELECT COUNT(*) FROM comment_likes WHERE comment_likes.comment_id = comments.id) AS likes_count
           FROM comments
           JOIN users ON comments.user_id = users.id

--- a/models/commentModel.js
+++ b/models/commentModel.js
@@ -1,12 +1,27 @@
 const db = require('../db');
 
 exports.getAllComments = async () => {
-  const result = await db.query('SELECT * FROM comments ORDER BY created_at DESC;');
+  const result = await db.query(`
+        SELECT comments.*, 
+               users.username AS user_name,
+               (SELECT COUNT(*) FROM comment_likes WHERE comment_likes.comment_id = comments.id) AS likes_count
+        FROM comments
+        JOIN users ON comments.user_id = users.id
+        ORDER BY comments.created_at DESC;
+    `);
   return result.rows;
 }
 
 exports.getCommentsByPostId = async (post_id) => {
-  const result = await db.query('SELECT * FROM comments WHERE post_id = $1', [post_id]);
+  const result = await db.query(`
+    SELECT comments.*, 
+           users.username AS user_name,
+           (SELECT COUNT(*) FROM comment_likes WHERE comment_likes.comment_id = comments.id) AS likes_count
+    FROM comments
+    JOIN users ON comments.user_id = users.id
+    WHERE comments.post_id = $1
+    ORDER BY comments.created_at ASC;
+`, [post_id]);
   return result.rows;
 };
 
@@ -26,7 +41,8 @@ exports.getCommentById = async (id) => {
 exports.getCommentsWithReplies = async (post_id) => {
   try {
     const result = await db.query(`
-          SELECT comments.*, users.username AS user_name
+          SELECT comments.*, users.username AS user_name,
+           (SELECT COUNT(*) FROM comment_likes WHERE comment_likes.comment_id = comments.id) AS likes_count
           FROM comments
           JOIN users ON comments.user_id = users.id
           WHERE comments.post_id = $1
@@ -85,4 +101,42 @@ exports.updateComment = async (id, content) => {
 
 exports.deleteComment = async (id) => {
   await db.query(`DELETE FROM comments WHERE id = $1`, [id]);
+};
+
+exports.toggleCommentLike = async (user_id, comment_id) => {
+  try {
+    const checkResult = await db.query(
+      `SELECT * FROM comment_likes WHERE user_id = $1 AND comment_id = $2;`,
+      [user_id, comment_id]
+    );
+
+    if (checkResult.rows.length > 0) {
+      await db.query(`DELETE FROM comment_likes WHERE user_id = $1 AND comment_id = $2;`,
+        [user_id, comment_id]);
+      return { liked: false };
+    } else {
+      await db.query(
+        `INSERT INTO comment_likes (user_id, comment_id) VALUES ($1, $2);`,
+        [user_id, comment_id]
+      );
+      return { liked: true };
+    }
+  } catch (error) {
+    throw error;
+  }
+};
+
+exports.getCommentLikes = async (comment_id) => {
+  try {
+    const result = await db.query(`
+      SELECT users.id AS user_id, users.username 
+      FROM comment_likes 
+      JOIN users ON comment_likes.user_id = users.id
+      WHERE comment_likes.comment_id = $1;
+  `, [comment_id]);
+
+    return result.rows;
+  } catch (error) {
+    throw error;
+  }
 };

--- a/models/paymentModel.js
+++ b/models/paymentModel.js
@@ -1,27 +1,5 @@
 const db = require('../db');
 
-// exports.createPayment = async (user_id, amount, status) => {
-//   try {
-//     const result = await db.query(`
-//             INSERT INTO payments (id, user_id, amount, status, created_at)
-//             VALUES (gen_random_uuid(), $1, $2, $3, NOW()) RETURNING *;
-//         `, [user_id, amount, status]);
-//     return result.rows[0];
-//   } catch (error) {
-//     throw error;
-//   }
-// };
-
-
-
-// exports.getPaymentsByUser = async (userId) => {
-//   try {
-//     const result = await db.query(`SELECT * FROM payments WHERE user_id = $1 ORDER BY created_at DESC;`, [userId]);
-//     return result.rows;
-//   } catch (error) {
-//     throw error;
-//   }
-// };
 exports.createPayment = async (user_id, receiver_id, amount) => {
   try {
     const result = await db.query(`

--- a/models/postModel.js
+++ b/models/postModel.js
@@ -213,6 +213,7 @@ exports.getFullPostsWithComments = async () => {
     const commentResult = await db.query(`
       SELECT comments.*, 
       users.username AS user_name,
+      users.profile_picture,
       (SELECT COUNT(*) FROM comment_likes WHERE comment_likes.comment_id = comments.id) AS likes_count
       FROM comments
       JOIN users ON comments.user_id = users.id

--- a/models/postModel.js
+++ b/models/postModel.js
@@ -201,7 +201,9 @@ exports.getFullPostsWithComments = async () => {
 
     // 查詢這些文章的留言（包含巢狀留言）
     const commentResult = await db.query(`
-      SELECT comments.*, users.username AS user_name
+      SELECT comments.*, 
+      users.username AS user_name,
+      (SELECT COUNT(*) FROM comment_likes WHERE comment_likes.comment_id = comments.id) AS likes_count
       FROM comments
       JOIN users ON comments.user_id = users.id
       WHERE comments.post_id = ANY($1)

--- a/models/postModel.js
+++ b/models/postModel.js
@@ -7,7 +7,7 @@ exports.getPosts = async () => {
              categories.id AS category_id, categories.name AS category_name,
              COUNT(post_likes.user_id) AS likes_count,
              COUNT(post_favorites.user_id) AS favorites_count,
-             posts.image_url  -- 新增封面圖片 URL 欄位
+             posts.image_url,posts.views_count
       FROM posts
       JOIN users ON posts.user_id = users.id
       LEFT JOIN categories ON posts.category_id = categories.id
@@ -46,12 +46,18 @@ exports.getPosts = async () => {
 
 exports.getPostById = async (id) => {
   try {
+    // 先增加點閱數（views_count +1）
+    await db.query(`
+      UPDATE posts 
+      SET views_count = views_count + 1
+      WHERE id = $1;
+  `, [id]);
     const postResult = await db.query(`
       SELECT posts.*, users.username AS author_name, 
              categories.id AS category_id, categories.name AS category_name,
              COUNT(post_likes.user_id) AS likes_count,
              COUNT(post_favorites.user_id) AS favorites_count,
-             posts.image_url  -- 新增封面圖片 URL 欄位
+             posts.image_url,posts.views_count
       FROM posts
       JOIN users ON posts.user_id = users.id
       LEFT JOIN categories ON posts.category_id = categories.id
@@ -97,7 +103,7 @@ exports.getPostsByCategory = async (categoryId) => {
              categories.id AS category_id, categories.name AS category_name,
              COUNT(post_likes.user_id) AS likes_count,
              COUNT(post_favorites.user_id) AS favorites_count,
-             posts.image_url  -- 新增封面圖片 URL
+             posts.image_url,posts.views_count
       FROM posts
       JOIN users ON posts.user_id = users.id
       LEFT JOIN categories ON posts.category_id = categories.id
@@ -144,7 +150,7 @@ exports.getPostsByUser = async (userId) => {
              categories.id AS category_id, categories.name AS category_name,
              COUNT(post_likes.user_id) AS likes_count,
              COUNT(post_favorites.user_id) AS favorites_count,
-             posts.image_url  -- 新增封面圖片 URL
+             posts.image_url,posts.views_count
       FROM posts
       JOIN users ON posts.user_id = users.id
       LEFT JOIN categories ON posts.category_id = categories.id
@@ -194,7 +200,7 @@ exports.getFullPostsWithComments = async () => {
              categories.id AS category_id, categories.name AS category_name,
              COUNT(post_likes.user_id) AS likes_count,
              COUNT(post_favorites.user_id) AS favorites_count,
-             posts.image_url  -- 新增封面圖片 URL
+             posts.image_url,posts.views_count
       FROM posts
       JOIN users ON posts.user_id = users.id
       LEFT JOIN categories ON posts.category_id = categories.id

--- a/routes/commentRoutes.js
+++ b/routes/commentRoutes.js
@@ -10,4 +10,7 @@ router.post('/', authMiddleware, commentController.createComment);
 router.put('/:id', authMiddleware, commentController.updateComment);
 router.delete('/:id', authMiddleware, commentController.deleteComment);
 
+router.post('/comment_likes/:comment_id', authMiddleware, commentController.toggleCommentLike);
+router.get('/comment_likes/:comment_id', commentController.getCommentLikes);
+
 module.exports = router;

--- a/routes/postRoutes.js
+++ b/routes/postRoutes.js
@@ -8,7 +8,6 @@ const router = express.Router();
 // 文章相關 API
 router.get('/', postController.getPosts);
 router.get('/full', postController.getFullPostsWithComments);
-router.get('/:id', postController.getPostById);
 router.get('/search', postController.searchPostsByTags);
 router.get('/user/:userId', postController.getPostsByUser);
 router.get('/category/:categoryId', postController.getPostsByCategory);
@@ -18,6 +17,11 @@ router.post('/', authMiddleware, postController.createPost);
 router.post('/:id/tags', authMiddleware, postController.addTagsToPost);
 router.post("/post_likes/:postId", authMiddleware, postController.togglePostLike);
 
+router.post('/favorites/:post_id', authMiddleware, postController.togglePostFavorite);
+router.get('/favorites', authMiddleware, postController.getUserFavorites);
+
+router.get('/:id', postController.getPostById);
+
 router.patch('/:id', authMiddleware, postController.updatePost);
 router.delete('/:id', authMiddleware, postController.deletePost);
 
@@ -26,17 +30,17 @@ router.delete('/:id', authMiddleware, postController.deletePost);
 // ✅ 設定 Multer，確保 `uploads/` 目錄存在
 const storage = multer.diskStorage({
   destination: function (req, file, cb) {
-      const uploadPath = "uploads/";
-      if (!fs.existsSync(uploadPath)) {
-          fs.mkdirSync(uploadPath, { recursive: true });
-      }
-      cb(null, uploadPath);
+    const uploadPath = "uploads/";
+    if (!fs.existsSync(uploadPath)) {
+      fs.mkdirSync(uploadPath, { recursive: true });
+    }
+    cb(null, uploadPath);
   },
   filename: function (req, file, cb) {
     let sanitizedFileName = file.originalname.normalize("NFC")  // 修正 Unicode 亂碼
       .replace(/\s/g, "_")// 空格轉 `_`
       .replace(/[^\w.-]/g, ""); // 移除特殊字符 
-      cb(null,`${Date.now()}-${sanitizedFileName}`); // ✅ 確保唯一性
+    cb(null, `${Date.now()}-${sanitizedFileName}`); // ✅ 確保唯一性
   }
 });
 


### PR DESCRIPTION
Timo：

此次主要更新文章收藏以及留言按讚

### 文章收藏
- 新增post_favorites資料表
- POST方法為toggle模式，不用帶body，請求第一次為`true`，第二次為`false`，依此類推
- GET方法需帶token，可查詢使用者收藏清單
- 同步於所有文章相關的GET，新增`favorites_count`數值

### 留言按讚
- POST方法為toggle模式，不用帶body，請求第一次為`true`，第二次為`false`，依此類推
- GET方法於路由帶入留言ID，可查詢留言按讚清單
- 同步於所有留言相關的GET，新增`likes_count`數值

## 功能更新
- 留言的GET新增`profile_picture`資訊
- 文章的GET新增`views_count` 數值

### views_count運作方式
1. 新增文章時，views_count預設為"0"
2. 透過**/api/posts/{post_id}**發出請求時，會將該文章的views_count加1
